### PR TITLE
Add EPS support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,26 +1,31 @@
-Package: rsvg
 Type: Package
-Title: Render SVG Images into PDF, PNG, PostScript, or Bitmap Arrays
-Version: 2.1.2
-Authors@R: person("Jeroen", "Ooms", role = c("aut", "cre"), email = "jeroen@berkeley.edu",
-    comment = c(ORCID = "0000-0002-4035-0289"))
-Description: Renders vector-based svg images into high-quality custom-size bitmap
-    arrays using 'librsvg2'. The resulting bitmap can be written to e.g. png, jpeg
-    or webp format. In addition, the package can convert images directly to various
-    formats such as pdf or postscript.
+Package: rsvg
+Title: Render SVG Images into PDF, PNG, (Encapsulated) PostScript, or Bitmap Arrays
+Version: 2.1.2.9000
+Authors@R: c(
+    person("Jeroen", "Ooms", , "jeroen@berkeley.edu", role = c("aut", "cre"),
+           comment = c(ORCID = "0000-0002-4035-0289")),
+    person("Salim", "Brüggemann", , "salim-b@pm.me", role = c("ctb"),
+           comment = c(ORCID = "0000-0002-5329-5987"))
+  )
+Description: Renders vector-based svg images into high-quality custom-size
+    bitmap arrays using 'librsvg2'. The resulting bitmap can be written to
+    e.g. png, jpeg or webp format. In addition, the package can convert
+    images directly to various formats such as pdf or postscript.
 License: MIT + file LICENSE
 URL: https://github.com/jeroen/rsvg#readme
 BugReports: https://github.com/jeroen/rsvg/issues
-SystemRequirements: librsvg2
-RoxygenNote: 7.1.1
 Suggests:
-    spelling, 
-    svglite, 
-    magick, 
-    webp, 
     ggplot2,
     knitr,
-    rmarkdown
-Language: en-US
-VignetteBuilder: knitr
+    magick,
+    rmarkdown,
+    spelling,
+    svglite,
+    webp
+VignetteBuilder: 
+    knitr
 Encoding: UTF-8
+Language: en-US
+RoxygenNote: 7.1.2
+SystemRequirements: librsvg2

--- a/NAMESPACE
+++ b/NAMESPACE
@@ -2,6 +2,7 @@
 
 export(librsvg_version)
 export(rsvg)
+export(rsvg_eps)
 export(rsvg_pdf)
 export(rsvg_png)
 export(rsvg_ps)

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,6 @@
+2.1.2.9000
+  - Add `rsvg_eps()` which converts to Encapsulated PostScript (EPS) format (@salim-b)
+
 2.1.2
   - Windows: update to librsvg v2.48.8
   - Add ucrt64 support

--- a/R/rsvg.R
+++ b/R/rsvg.R
@@ -21,11 +21,12 @@
 #' ggplot2::qplot(mpg, wt, data = mtcars, colour = factor(cyl))
 #' dev.off()
 #'
-#' # convert directly into a bitmap format
+#' # convert directly into a vector or bitmap graphics format
 #' rsvg_pdf(tmp, "out.pdf")
 #' rsvg_png(tmp, "out.png")
 #' rsvg_svg(tmp, "out.svg")
 #' rsvg_ps(tmp, "out.ps")
+#' rsvg_eps(tmp, "out.eps")
 #'
 #' # render into raw bitmap array
 #' bitmap <- rsvg(tmp, height = 1440)

--- a/R/rsvg.R
+++ b/R/rsvg.R
@@ -88,7 +88,13 @@ rsvg_ps <- function(svg, file = NULL, width = NULL, height = NULL, css = NULL) {
   rsvg_format(svg, file, width = width, height = height, css = css, format = 4L)
 }
 
-rsvg_format <- function(svg, file = NULL, width = NULL, height = NULL, css = NULL, format = 0) {
+#' @rdname rsvg
+#' @export
+rsvg_eps <- function(svg, file = NULL, width = NULL, height = NULL, css = NULL) {
+  rsvg_format(svg, file, width = width, height = height, css = css, format = 5L)
+}
+
+rsvg_format <- function(svg, file = NULL, width = NULL, height = NULL, css = NULL, format = 0L) {
   svg <- read_data(svg)
   if(length(css)){
     css <- read_data(css)

--- a/man/rsvg.Rd
+++ b/man/rsvg.Rd
@@ -54,11 +54,12 @@ svglite::svglite(tmp, width = 10, height = 7)
 ggplot2::qplot(mpg, wt, data = mtcars, colour = factor(cyl))
 dev.off()
 
-# convert directly into a bitmap format
+# convert directly into a vector or bitmap graphics format
 rsvg_pdf(tmp, "out.pdf")
 rsvg_png(tmp, "out.png")
 rsvg_svg(tmp, "out.svg")
 rsvg_ps(tmp, "out.ps")
+rsvg_eps(tmp, "out.eps")
 
 # render into raw bitmap array
 bitmap <- rsvg(tmp, height = 1440)

--- a/man/rsvg.Rd
+++ b/man/rsvg.Rd
@@ -8,6 +8,7 @@
 \alias{rsvg_pdf}
 \alias{rsvg_svg}
 \alias{rsvg_ps}
+\alias{rsvg_eps}
 \title{Render SVG into Bitmap}
 \usage{
 rsvg(svg, width = NULL, height = NULL, css = NULL)
@@ -23,6 +24,8 @@ rsvg_pdf(svg, file = NULL, width = NULL, height = NULL, css = NULL)
 rsvg_svg(svg, file = NULL, width = NULL, height = NULL, css = NULL)
 
 rsvg_ps(svg, file = NULL, width = NULL, height = NULL, css = NULL)
+
+rsvg_eps(svg, file = NULL, width = NULL, height = NULL, css = NULL)
 }
 \arguments{
 \item{svg}{path/url to svg file or raw vector with svg data. Use \link{charToRaw} to convert

--- a/src/rsvg.c
+++ b/src/rsvg.c
@@ -72,9 +72,11 @@ static SEXP write_png(RsvgHandle *svg, int width, int height, double sx, double 
   return res;
 }
 
-static SEXP write_stream(RsvgHandle *svg, int width, int height, double sx, double sy, cairo_surface_t* (*fun) (cairo_write_func_t, void *, double, double)) {
+static SEXP write_stream(RsvgHandle *svg, int width, int height, double sx, double sy, cairo_surface_t* (*fun) (cairo_write_func_t, void *, double, double), cairo_bool_t is_eps) {
   memory buf = {NULL, 0};
   cairo_surface_t *canvas = fun(write_func, &buf, width, height);
+  if(is_eps)
+    cairo_ps_surface_set_eps(canvas, TRUE);
   cairo_t *cr = cairo_create(canvas);
   cairo_scale(cr, sx, sy);
   if(!rsvg_handle_render_cairo(svg, cr))
@@ -139,11 +141,13 @@ SEXP R_rsvg(SEXP data, SEXP rwidth, SEXP rheight, SEXP format, SEXP css){
   case 1:
     return write_png(svg, width, height, sx, sy);
   case 2:
-    return write_stream(svg, width, height, sx, sy, cairo_pdf_surface_create_for_stream);
+    return write_stream(svg, width, height, sx, sy, cairo_pdf_surface_create_for_stream, FALSE);
   case 3:
-    return write_stream(svg, width, height, sx, sy, cairo_svg_surface_create_for_stream);
+    return write_stream(svg, width, height, sx, sy, cairo_svg_surface_create_for_stream, FALSE);
   case 4:
-    return write_stream(svg, width, height, sx, sy, cairo_ps_surface_create_for_stream);
+    return write_stream(svg, width, height, sx, sy, cairo_ps_surface_create_for_stream, FALSE);
+  case 5:
+    return write_stream(svg, width, height, sx, sy, cairo_ps_surface_create_for_stream, TRUE);
   }
   return R_NilValue;
 }


### PR DESCRIPTION
Adds `rsvg_eps()` which converts to Encapsulated PostScript (EPS) format.

Note that I'm a complete C noob (I 🤞 the C changes are fine). The relevant code part ([`cairo_ps_surface_set_eps(surface, TRUE);`](https://www.cairographics.org/manual/cairo-PostScript-Surfaces.html#cairo-ps-surface-set-eps)) was found [in this librsvg commit](https://mail.gnome.org/archives/commits-list/2013-October/msg03864.html).