### PR TITLE
add nativeraster

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -3,6 +3,7 @@
 export(librsvg_version)
 export(rsvg)
 export(rsvg_eps)
+export(rsvg_nativeraster)
 export(rsvg_pdf)
 export(rsvg_png)
 export(rsvg_ps)

--- a/R/rsvg.R
+++ b/R/rsvg.R
@@ -32,6 +32,10 @@
 #' bitmap <- rsvg(tmp, height = 1440)
 #' dim(bitmap) # h*w*c
 #'
+#' # render to native raster object
+#' nr <- rsvg_nativeraster(tmp)
+#' # grid::grid.raster(nr)
+#'
 #' # read in your package of choice
 #' magick::image_read(bitmap)
 #' webp::write_webp(bitmap, "bitmap.webp", quality = 100)
@@ -55,6 +59,18 @@ rsvg_raw <- function(svg, width = NULL, height = NULL, css = NULL) {
   stopifnot(is.null(height) || is.numeric(height))
   out <- .Call(R_rsvg, svg, width, height, 0L, css)
   out[c(3,2,1,4),,, drop = FALSE]
+}
+
+#' @rdname rsvg
+#' @export
+rsvg_nativeraster <- function(svg, width = NULL, height = NULL, css = NULL) {
+  svg <- read_data(svg)
+  if(length(css)){
+    css <- read_data(css)
+  }
+  stopifnot(is.null(width) || is.numeric(width))
+  stopifnot(is.null(height) || is.numeric(height))
+  .Call(R_rsvg, svg, width, height, 6L, css)
 }
 
 #' @rdname rsvg

--- a/man/rsvg.Rd
+++ b/man/rsvg.Rd
@@ -3,6 +3,7 @@
 \name{rsvg}
 \alias{rsvg}
 \alias{rsvg_raw}
+\alias{rsvg_nativeraster}
 \alias{rsvg_webp}
 \alias{rsvg_png}
 \alias{rsvg_pdf}
@@ -14,6 +15,8 @@
 rsvg(svg, width = NULL, height = NULL, css = NULL)
 
 rsvg_raw(svg, width = NULL, height = NULL, css = NULL)
+
+rsvg_nativeraster(svg, width = NULL, height = NULL, css = NULL)
 
 rsvg_webp(svg, file = NULL, width = NULL, height = NULL, css = NULL)
 
@@ -64,6 +67,10 @@ rsvg_eps(tmp, "out.eps")
 # render into raw bitmap array
 bitmap <- rsvg(tmp, height = 1440)
 dim(bitmap) # h*w*c
+
+# render to native raster object
+nr <- rsvg_nativeraster(tmp)
+# grid::grid.raster(nr)
 
 # read in your package of choice
 magick::image_read(bitmap)


### PR DESCRIPTION
This PR adds export to 'nativeRaster' format.  This is a native R raster format which represents the ARGB values at each pixel location as a single 32bit integer.

nativeRaster format is fast to compute from the cairo canvas, and fast to plot natively in R using grid.raster()